### PR TITLE
Fix unreadable title links

### DIFF
--- a/inject/inject.css
+++ b/inject/inject.css
@@ -19,7 +19,7 @@ b {
   color: #fafafa;
 }
 
-td>.title {
+td.title {
   color: #fafafa;
 }
 
@@ -53,7 +53,7 @@ td>a:link {
   color: #8c96ac;
 }
 
-.title>a:link {
+.titleline>a:link {
   color: #8c96ac;
 }
 
@@ -65,7 +65,7 @@ a>u {
   color: #8c96ac;
 }
 
-.title>a:visited {
+.titleline>a:visited {
   color: #979cf4;
 }
 


### PR DESCRIPTION
There must have been a recent change to hackernews's html, as the title links are now black which is not readable against the dark background.

This slight css change makes them their previous readable blueish color.

Old:
<img width="661" alt="old" src="https://user-images.githubusercontent.com/472066/198161302-e6405bca-cf37-4571-8121-473d82578f40.png">

New (with this change):
<img width="655" alt="new" src="https://user-images.githubusercontent.com/472066/198161318-c7f2e813-ac3b-46e0-8002-e7ba57c6f326.png">
